### PR TITLE
Add onboarding and dashboard skeleton

### DIFF
--- a/iPadStartKlasse8/ContentView.swift
+++ b/iPadStartKlasse8/ContentView.swift
@@ -1,21 +1,17 @@
-//
-//  ContentView.swift
-//  iPadStartKlasse8
-//
-//  Created by Stefan Megerle on 24.07.25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @State private var student = Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
+    @State private var isRegistered = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        if isRegistered {
+            DashboardView(student: student)
+        } else {
+            OnboardingView(student: $student) {
+                isRegistered = true
+            }
         }
-        .padding()
     }
 }
 

--- a/iPadStartKlasse8/Core/Models/Student.swift
+++ b/iPadStartKlasse8/Core/Models/Student.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Student: Identifiable, Codable {
+    var id: UUID
+    var firstName: String
+    var lastName: String
+    var className: String
+    var studentID: String
+}

--- a/iPadStartKlasse8/Features/Dashboard/DashboardView.swift
+++ b/iPadStartKlasse8/Features/Dashboard/DashboardView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct DashboardView: View {
+    var student: Student
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("Willkommen, \(student.firstName)!")
+                    .font(.title)
+                ProgressView(value: 0.2)
+                    .progressViewStyle(.linear)
+                Text("Hier werden deine Aufgaben angezeigt.")
+            }
+            .padding()
+            .navigationTitle("Dashboard")
+        }
+    }
+}
+
+#Preview {
+    DashboardView(student: Student(id: UUID(), firstName: "Max", lastName: "Muster", className: "8A", studentID: "1234"))
+}

--- a/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
+++ b/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @Binding var student: Student
+    var onContinue: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Persönliche Daten")) {
+                    TextField("Vorname", text: $student.firstName)
+                    TextField("Nachname", text: $student.lastName)
+                    TextField("Klasse", text: $student.className)
+                    TextField("ID", text: $student.studentID)
+                }
+                Button("Weiter") {
+                    onContinue()
+                }
+                .disabled(student.firstName.isEmpty || student.lastName.isEmpty || student.className.isEmpty || student.studentID.isEmpty)
+            }
+            .navigationTitle("Registrierung")
+        }
+    }
+}
+
+#Preview {
+    @State var student = Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
+    return OnboardingView(student: $student) {}
+}


### PR DESCRIPTION
## Summary
- add modular folders with a Student model
- create onboarding form with registration fields
- create a simple dashboard view
- update `ContentView` to switch between onboarding and dashboard

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882688706cc8321bd298adb07d50f19