### PR TITLE
Add sample tasks feature

### DIFF
--- a/iPadStartKlasse8/ContentView.swift
+++ b/iPadStartKlasse8/ContentView.swift
@@ -1,21 +1,17 @@
-//
-//  ContentView.swift
-//  iPadStartKlasse8
-//
-//  Created by Stefan Megerle on 24.07.25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @State private var student = Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
+    @State private var isRegistered = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        if isRegistered {
+            DashboardView(student: student)
+        } else {
+            OnboardingView(student: $student) {
+                isRegistered = true
+            }
         }
-        .padding()
     }
 }
 

--- a/iPadStartKlasse8/Core/Models/AppTask.swift
+++ b/iPadStartKlasse8/Core/Models/AppTask.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum EvidenceType: String, Codable {
+    case text
+    case photo
+    case video
+    case link
+    case file
+}
+
+struct AppTask: Identifiable, Codable {
+    var id: UUID
+    var title: String
+    var description: String
+    var evidence: EvidenceType
+}
+
+extension AppTask {
+    static var sampleTasks: [AppTask] {
+        [
+            AppTask(id: UUID(), title: "Essay schreiben", description: "Schreibe einen kurzen Aufsatz.", evidence: .text),
+            AppTask(id: UUID(), title: "Foto hochladen", description: "Lade ein Foto deiner Arbeit hoch.", evidence: .photo),
+            AppTask(id: UUID(), title: "Video aufnehmen", description: "Nimm ein kurzes Video auf.", evidence: .video),
+            AppTask(id: UUID(), title: "Link teilen", description: "Füge einen nützlichen Link hinzu.", evidence: .link),
+            AppTask(id: UUID(), title: "Datei abgeben", description: "Lade eine Datei hoch.", evidence: .file)
+        ]
+    }
+}

--- a/iPadStartKlasse8/Core/Models/Student.swift
+++ b/iPadStartKlasse8/Core/Models/Student.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Student: Identifiable, Codable {
+    var id: UUID
+    var firstName: String
+    var lastName: String
+    var className: String
+    var studentID: String
+}

--- a/iPadStartKlasse8/Features/Dashboard/DashboardView.swift
+++ b/iPadStartKlasse8/Features/Dashboard/DashboardView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+// Simple dashboard displaying a welcome message and link to tasks
+
+struct DashboardView: View {
+    var student: Student
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("Willkommen, \(student.firstName)!")
+                    .font(.title)
+                ProgressView(value: 0.2)
+                    .progressViewStyle(.linear)
+                NavigationLink("Zu deinen Aufgaben") {
+                    TaskListView(tasks: AppTask.sampleTasks)
+                }
+            }
+            .padding()
+            .navigationTitle("Dashboard")
+        }
+    }
+}
+
+#Preview {
+    DashboardView(student: Student(id: UUID(), firstName: "Max", lastName: "Muster", className: "8A", studentID: "1234"))
+}

--- a/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
+++ b/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @Binding var student: Student
+    var onContinue: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Persönliche Daten")) {
+                    TextField("Vorname", text: $student.firstName)
+                    TextField("Nachname", text: $student.lastName)
+                    TextField("Klasse", text: $student.className)
+                    TextField("ID", text: $student.studentID)
+                }
+                Button("Weiter") {
+                    onContinue()
+                }
+                .disabled(student.firstName.isEmpty || student.lastName.isEmpty || student.className.isEmpty || student.studentID.isEmpty)
+            }
+            .navigationTitle("Registrierung")
+        }
+    }
+}
+
+#Preview {
+    @State var student = Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
+    return OnboardingView(student: $student) {}
+}

--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Displays a simple list of demo tasks with detail view
+
+struct TaskListView: View {
+    var tasks: [AppTask]
+
+    var body: some View {
+        List(tasks) { task in
+            NavigationLink(destination: TaskDetailView(task: task)) {
+                Text(task.title)
+            }
+        }
+        .navigationTitle("Aufgaben")
+    }
+}
+
+struct TaskDetailView: View {
+    var task: AppTask
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(task.description)
+            Text("Nachweis: \(task.evidence.rawValue)")
+        }
+        .padding()
+        .navigationTitle(task.title)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TaskListView(tasks: AppTask.sampleTasks)
+    }
+}


### PR DESCRIPTION
## Summary
- model demo `AppTask` objects
- build a simple task list with detail view
- link tasks from the dashboard

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882688706cc8321bd298adb07d50f19