### PR TITLE
Fix tasks view opening first task

### DIFF
--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -4,19 +4,29 @@ import SwiftUI
 
 struct TaskListView: View {
     @Binding var tasks: [AppTask]
+    @State private var selectedTaskID: AppTask.ID?
 
     var body: some View {
-        List {
-            ForEach($tasks) { $task in
-                NavigationLink(destination: TaskDetailView(task: $task)) {
+        NavigationSplitView {
+            List(selection: $selectedTaskID) {
+                ForEach($tasks) { $task in
                     HStack {
                         Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
                         Text(task.title)
                     }
+                    .tag(task.id)
                 }
             }
+            .navigationTitle("Aufgaben")
+        } detail: {
+            if let selectedID = selectedTaskID,
+               let index = tasks.firstIndex(where: { $0.id == selectedID }) {
+                TaskDetailView(task: $tasks[index])
+            } else {
+                Text("Wähle eine Aufgabe")
+                    .foregroundStyle(.secondary)
+            }
         }
-        .navigationTitle("Aufgaben")
     }
 }
 
@@ -36,7 +46,5 @@ struct TaskDetailView: View {
 
 #Preview {
     @Previewable @State var demoTasks = AppTask.sampleTasks
-    return NavigationStack {
-        TaskListView(tasks: $demoTasks)
-    }
+    return TaskListView(tasks: $demoTasks)
 }


### PR DESCRIPTION
## Summary
- update `TaskListView` to use `NavigationSplitView`
- keep selection empty by default so opening the list shows an overview instead of immediately pushing the first task

## Testing
- `swift test` *(fails: no Package.swift)*
- `xcodebuild -list -project iPadStartKlasse8.xcodeproj` *(fails: xcodebuild not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882756eccf483218a04aeebde033b3b