### PR TITLE
Add subject categories for tasks

### DIFF
--- a/iPadStartKlasse8/Core/Models/AppTask.swift
+++ b/iPadStartKlasse8/Core/Models/AppTask.swift
@@ -6,12 +6,24 @@ enum EvidenceType: String, Codable {
     case video
     case link
     case file
+    case audio
+}
+
+enum Subject: String, Codable, CaseIterable, Identifiable {
+    case deutsch = "Deutsch"
+    case mathematik = "Mathematik"
+    case naturwissenschaften = "Naturwissenschaften"
+    case fremdsprachen = "Fremdsprachen"
+    case kunst = "Kunst"
+
+    var id: String { rawValue }
 }
 
 struct AppTask: Identifiable, Codable {
     var id: UUID
     var title: String
     var description: String
+    var subject: Subject
     var evidence: EvidenceType
     var isCompleted: Bool = false
 }
@@ -19,11 +31,22 @@ struct AppTask: Identifiable, Codable {
 extension AppTask {
     static var sampleTasks: [AppTask] {
         [
-            AppTask(id: UUID(), title: "Essay schreiben", description: "Schreibe einen kurzen Aufsatz.", evidence: .text),
-            AppTask(id: UUID(), title: "Foto hochladen", description: "Lade ein Foto deiner Arbeit hoch.", evidence: .photo),
-            AppTask(id: UUID(), title: "Video aufnehmen", description: "Nimm ein kurzes Video auf.", evidence: .video),
-            AppTask(id: UUID(), title: "Link teilen", description: "Füge einen nützlichen Link hinzu.", evidence: .link),
-            AppTask(id: UUID(), title: "Datei abgeben", description: "Lade eine Datei hoch.", evidence: .file)
+            // Deutsch
+            AppTask(id: UUID(), title: "Mebis-Kurs benutzt", description: "Einen Kurs in Mebis geöffnet und bearbeitet.", subject: .deutsch, evidence: .link),
+            AppTask(id: UUID(), title: "Online-Übung gemacht", description: "Eine Online-Übung bearbeitet.", subject: .deutsch, evidence: .text),
+            AppTask(id: UUID(), title: "Digitalen Jahrgangsstufentest auf Mebis bearbeitet", description: "Den Jahrgangsstufentest online gelöst.", subject: .deutsch, evidence: .file),
+
+            // Mathematik
+            AppTask(id: UUID(), title: "Grundlegende Fähigkeiten in GoodNotes", description: "Notizen in GoodNotes erstellt.", subject: .mathematik, evidence: .file),
+
+            // Naturwissenschaften
+            AppTask(id: UUID(), title: "Erklärvideo erstellen", description: "Ein Erklärvideo zu einem Thema aufnehmen.", subject: .naturwissenschaften, evidence: .video),
+
+            // Fremdsprachen
+            AppTask(id: UUID(), title: "Audioaufnahme anfertigen", description: "Einen kurzen Text aufnehmen.", subject: .fremdsprachen, evidence: .audio),
+
+            // Kunst
+            AppTask(id: UUID(), title: "Film erstellen", description: "Einen kurzen Film drehen.", subject: .kunst, evidence: .video)
         ]
     }
 }

--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -9,12 +9,20 @@ struct TaskListView: View {
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedTaskID) {
-                ForEach($tasks) { $task in
-                    HStack {
-                        Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
-                        Text(task.title)
+                ForEach(Subject.allCases) { subject in
+                    let indices = tasks.indices.filter { tasks[$0].subject == subject }
+                    if !indices.isEmpty {
+                        Section(subject.rawValue) {
+                            ForEach(indices, id: \.self) { index in
+                                let task = tasks[index]
+                                HStack {
+                                    Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")
+                                    Text(task.title)
+                                }
+                                .tag(task.id)
+                            }
+                        }
                     }
-                    .tag(task.id)
                 }
             }
             .navigationTitle("Aufgaben")


### PR DESCRIPTION
## Summary
- add audio evidence type and subject categories
- extend `AppTask` model with new `subject` field
- provide subject-specific demo tasks
- group tasks by subject in `TaskListView`

## Testing
- `swift --version`
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688315b8a11883218f16137b9b15c099