### PR TITLE
Persist user data between launches

### DIFF
--- a/iPadStartKlasse8/ContentView.swift
+++ b/iPadStartKlasse8/ContentView.swift
@@ -1,23 +1,34 @@
 
- import SwiftUI
- 
- struct ContentView: View {
- @State private var student = Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
-@State private var isRegistered = false
- @State private var tasks = AppTask.sampleTasks
+import SwiftUI
 
-     var body: some View {
+/// Root view that either shows onboarding or the dashboard.
+struct ContentView: View {
+    @State private var student: Student = {
+        LocalDataStore.shared.loadStudent() ??
+            Student(id: UUID(), firstName: "", lastName: "", className: "", studentID: "")
+    }()
+    @State private var isRegistered: Bool = LocalDataStore.shared.loadStudent() != nil
+    @State private var tasks: [AppTask] = {
+        let stored = LocalDataStore.shared.loadTasks()
+        return stored.isEmpty ? AppTask.sampleTasks : stored
+    }()
 
-if isRegistered {
- DashboardView(student: student, tasks: $tasks)
-    } else {
-          OnboardingView(student: $student) {
-              isRegistered = true
-         }
-         }
+    var body: some View {
+        if isRegistered {
+            DashboardView(student: student, tasks: $tasks)
+                .onChange(of: tasks) { newValue in
+                    LocalDataStore.shared.save(tasks: newValue)
+                }
+        } else {
+            OnboardingView(student: $student) {
+                isRegistered = true
+                LocalDataStore.shared.save(student: student)
+                LocalDataStore.shared.save(tasks: tasks)
+            }
+        }
 
-     }
- }
+    }
+}
  
  #Preview {
      ContentView()

--- a/iPadStartKlasse8/Core/Persistence/LocalDataStore.swift
+++ b/iPadStartKlasse8/Core/Persistence/LocalDataStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Simple helper to persist student and task data locally as JSON files.
+struct LocalDataStore {
+    static let shared = LocalDataStore()
+
+    private let studentURL: URL
+    private let tasksURL: URL
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        studentURL = documents.appendingPathComponent("student.json")
+        tasksURL = documents.appendingPathComponent("tasks.json")
+    }
+
+    // MARK: Student
+    func loadStudent() -> Student? {
+        guard let data = try? Data(contentsOf: studentURL) else { return nil }
+        return try? JSONDecoder().decode(Student.self, from: data)
+    }
+
+    func save(student: Student) {
+        do {
+            let data = try JSONEncoder().encode(student)
+            try data.write(to: studentURL, options: .atomic)
+        } catch {
+            print("Failed to save student: \(error)")
+        }
+    }
+
+    // MARK: Tasks
+    func loadTasks() -> [AppTask] {
+        guard let data = try? Data(contentsOf: tasksURL) else { return [] }
+        return (try? JSONDecoder().decode([AppTask].self, from: data)) ?? []
+    }
+
+    func save(tasks: [AppTask]) {
+        do {
+            let data = try JSONEncoder().encode(tasks)
+            try data.write(to: tasksURL, options: .atomic)
+        } catch {
+            print("Failed to save tasks: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- store and load `Student` and `AppTask` using `LocalDataStore`
- load saved data at app launch in `ContentView`
- save tasks and user info when modified

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6885c4a0ecbc83219ee9c83d0b1dc00a