### PR TITLE
Ensure side panel visible in tasks

### DIFF
--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -5,9 +5,10 @@ import SwiftUI
 struct TaskListView: View {
     @Binding var tasks: [AppTask]
     @State private var selectedTaskID: AppTask.ID?
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             List(selection: $selectedTaskID) {
                 ForEach(Subject.allCases) { subject in
                     let indices = tasks.indices.filter { tasks[$0].subject == subject }


### PR DESCRIPTION
## Summary
- keep `NavigationSplitView` columns shown in `TaskListView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6885c8d9647c8321992853d5e82537f6