### PR TITLE
Add audio import share extension

### DIFF
--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>de.example.iPadStartKlasse8.ShareExtension</string>
+    <key>CFBundleName</key>
+    <string>Audio Import</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSItemContentTypes</key>
+    <array>
+        <string>public.audio</string>
+    </array>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.share-services</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+    </dict>
+</dict>
+</plist>

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -1,0 +1,43 @@
+import UIKit
+import UniformTypeIdentifiers
+
+/// Minimal share extension to import audio files from Voice Memos.
+class ShareViewController: UIViewController {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        handleInput()
+    }
+
+    private func handleInput() {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let attachments = item.attachments else {
+            complete()
+            return
+        }
+
+        for provider in attachments {
+            if provider.hasItemConformingToTypeIdentifier(UTType.audio.identifier) {
+                provider.loadInPlaceFileRepresentation(forTypeIdentifier: UTType.audio.identifier) { url, inPlace, error in
+                    if let url {
+                        self.save(url: url)
+                    }
+                    self.complete()
+                }
+                return
+            }
+        }
+        complete()
+    }
+
+    private func save(url: URL) {
+        guard let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.appGroupID) else {
+            return
+        }
+        let destination = container.appendingPathComponent(url.lastPathComponent)
+        try? FileManager.default.copyItem(at: url, to: destination)
+    }
+
+    private func complete() {
+        extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+    }
+}

--- a/iPadStartKlasse8/Core/Persistence/LocalDataStore.swift
+++ b/iPadStartKlasse8/Core/Persistence/LocalDataStore.swift
@@ -10,7 +10,12 @@ struct LocalDataStore {
 
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
-        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let documents: URL
+        if let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: Constants.appGroupID) {
+            documents = container
+        } else {
+            documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        }
         studentURL = documents.appendingPathComponent("student.json")
         tasksURL = documents.appendingPathComponent("tasks.json")
     }

--- a/iPadStartKlasse8/Features/Tasks/AudioEvidenceListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/AudioEvidenceListView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Displays all audio files imported via the share extension.
+struct AudioEvidenceListView: View {
+    let files: [URL] = EvidenceStore.allAudioFiles()
+
+    var body: some View {
+        List(files, id: \.self) { url in
+            Text(url.lastPathComponent)
+        }
+        .navigationTitle("Importierte Audios")
+    }
+}
+
+#Preview {
+    AudioEvidenceListView()
+}

--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -47,6 +47,11 @@ struct TaskDetailView: View {
             Text(task.description)
             Text("Nachweis: \(task.evidence.rawValue)")
             Toggle("Erledigt", isOn: $task.isCompleted)
+            if task.evidence == .audio {
+                NavigationLink("Importierte Audios") {
+                    AudioEvidenceListView()
+                }
+            }
         }
         .padding()
         .navigationTitle(task.title)

--- a/iPadStartKlasse8/Shared/Constants.swift
+++ b/iPadStartKlasse8/Shared/Constants.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Shared configuration values used across targets.
+enum Constants {
+    /// The App Group identifier used for sharing files between the main app and extensions.
+    static let appGroupID = "group.de.example.iPadStartKlasse8"
+}

--- a/iPadStartKlasse8/Shared/EvidenceStore.swift
+++ b/iPadStartKlasse8/Shared/EvidenceStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Provides access to audio files stored via the share extension.
+struct EvidenceStore {
+    /// Directory within the shared container where audio files are saved.
+    private static var directory: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.appGroupID)
+    }
+
+    /// Returns URLs of all audio files that have been imported.
+    static func allAudioFiles() -> [URL] {
+        guard let dir = directory else { return [] }
+        return (try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+    }
+}


### PR DESCRIPTION
## Summary
- allow data store to use shared app group container
- add share extension target source to receive audio files
- track imported audio evidence and display in app
- show evidence list from task detail when the task needs audio

## Testing
- `swift test` *(fails: Package.swift missing)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885cc8efbc88321ad4847b73fd5926b