### PR TITLE
Embed art video tutorial

### DIFF
--- a/iPadStartKlasse8/Features/Tasks/TaskListView.swift
+++ b/iPadStartKlasse8/Features/Tasks/TaskListView.swift
@@ -52,6 +52,11 @@ struct TaskDetailView: View {
                     AudioEvidenceListView()
                 }
             }
+            if task.evidence == .video && task.subject == .kunst {
+                NavigationLink("Video erstellen") {
+                    VideoCreationView()
+                }
+            }
         }
         .padding()
         .navigationTitle(task.title)

--- a/iPadStartKlasse8/Features/Tasks/VideoCreationView.swift
+++ b/iPadStartKlasse8/Features/Tasks/VideoCreationView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import WebKit
+
+/// Displays an embedded YouTube tutorial for creating a video.
+struct VideoCreationView: View {
+    private let videoURL = URL(string: "https://www.youtube.com/embed/Ha9E9Zmthjw?si=zTEH0gPARYffhO0D")!
+
+    var body: some View {
+        WebView(url: videoURL)
+            .navigationTitle("Video erstellen")
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+/// Simple WebView wrapper to display web content.
+struct WebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.scrollView.isScrollEnabled = false
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.load(URLRequest(url: url))
+    }
+}
+
+#Preview {
+    VideoCreationView()
+}


### PR DESCRIPTION
## Summary
- show a link to the new "Video erstellen" view for the art video task
- implement `VideoCreationView` that embeds the YouTube tutorial

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688632ce001c8321b43ce63219f7e026