### PR TITLE
Ensure home screen always displays help categories

### DIFF
--- a/iPadStartKlasse8/Core/Models/FAQItem.swift
+++ b/iPadStartKlasse8/Core/Models/FAQItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct FAQItem: Identifiable, Codable {
-    var id: UUID
+    var id: String
     var question: String
     var answer: String
     var category: String

--- a/iPadStartKlasse8/Features/Help/HelpHomeView.swift
+++ b/iPadStartKlasse8/Features/Help/HelpHomeView.swift
@@ -3,25 +3,20 @@ import SwiftUI
 struct HelpHomeView: View {
     let items: [FAQItem]
 
-    private var categoriesWithIcons: [(String, String, String)] {
-        let categoryData: [String: (String, String)] = [
-            "Erste Schritte": ("play.circle.fill", "Grundlagen für den Start"),
-            "Apps & Tools": ("square.grid.2x2.fill", "Wichtige Apps und Werkzeuge"),
-            "Troubleshooting": ("wrench.and.screwdriver.fill", "Probleme lösen"),
-            "Dateien & Organisation": ("folder.fill", "Ordnung in deinen Dateien"),
-            "Kommunikation & Zusammenarbeit": ("person.2.fill", "Teamwork und Austausch"),
-            "Sicherheit & Verantwortung": ("shield.fill", "Sicher und verantwortlich"),
-            "Tipps & Tricks": ("lightbulb.fill", "Profi-Tipps für Fortgeschrittene"),
-            "Multimedia & Projekte": ("video.circle.fill", "Kreative Projekte")
-        ]
-        
-        return Set(items.map { $0.category })
-            .sorted()
-            .compactMap { category in
-                guard let (icon, description) = categoryData[category] else { return nil }
-                return (category, icon, description)
-            }
-    }
+    /// Static list of available categories with their icons and descriptions.
+    ///
+    /// Using a predefined list ensures that the home screen always shows
+    /// navigation options, even if the FAQ data fails to load or is empty.
+    private let categoriesWithIcons: [(String, String, String)] = [
+        ("Erste Schritte", "play.circle.fill", "Grundlagen für den Start"),
+        ("Apps & Tools", "square.grid.2x2.fill", "Wichtige Apps und Werkzeuge"),
+        ("Troubleshooting", "wrench.and.screwdriver.fill", "Probleme lösen"),
+        ("Dateien & Organisation", "folder.fill", "Ordnung in deinen Dateien"),
+        ("Kommunikation & Zusammenarbeit", "person.2.fill", "Teamwork und Austausch"),
+        ("Sicherheit & Verantwortung", "shield.fill", "Sicher und verantwortlich"),
+        ("Tipps & Tricks", "lightbulb.fill", "Profi-Tipps für Fortgeschrittene"),
+        ("Multimedia & Projekte", "video.circle.fill", "Kreative Projekte")
+    ]
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## Summary
- Always render the predefined help categories on the home screen so users can navigate even when FAQ data is missing.
- Decode FAQ items with string IDs so category views show their questions and answers.

## Testing
- `swift - <<'SWIFT'` *(confirm FAQItems.json decodes 26 items)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project iPadStartKlasse8.xcodeproj -scheme iPadStartKlasse8` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6890a725769c832181fa0028a2f49085