### PR TITLE
Use dashboard image as blurred background in help home view

### DIFF
--- a/iPadStartKlasse8/Features/Help/HelpHomeView.swift
+++ b/iPadStartKlasse8/Features/Help/HelpHomeView.swift
@@ -20,63 +20,71 @@ struct HelpHomeView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                LazyVStack(spacing: 16) {
-                    // Header section
-                    VStack(spacing: 12) {
-                        Text("Wie kann ich dir helfen?")
-                            .font(.system(size: 28, weight: .bold, design: .rounded))
-                            .foregroundColor(.primary)
-                            .multilineTextAlignment(.center)
-                        
-                        Text("Finde schnell Antworten auf deine iPad-Fragen")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 8)
-                    .padding(.bottom, 12)
-                    
-                    // Categories grid
-                    LazyVGrid(
-                        columns: [
-                            GridItem(.flexible(), spacing: 12),
-                            GridItem(.flexible(), spacing: 12)
-                        ],
-                        spacing: 16
-                    ) {
-                        ForEach(categoriesWithIcons, id: \.0) { category, icon, description in
-                            NavigationLink {
-                                FAQListView(
-                                    title: category, 
-                                    items: items.filter { $0.category == category }
-                                )
-                            } label: {
-                                CategoryCard(
-                                    title: category,
-                                    icon: icon,
-                                    description: description,
-                                    itemCount: items.filter { $0.category == category }.count
-                                )
-                            }
-                            .buttonStyle(PlainButtonStyle())
+            ZStack {
+                Image("DashboardBackground")
+                    .resizable()
+                    .scaledToFill()
+                    .blur(radius: 20)
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        // Header section
+                        VStack(spacing: 12) {
+                            Text("Wie kann ich dir helfen?")
+                                .font(.system(size: 28, weight: .bold, design: .rounded))
+                                .foregroundColor(.primary)
+                                .multilineTextAlignment(.center)
+
+                            Text("Finde schnell Antworten auf deine iPad-Fragen")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
                         }
+                        .padding(.horizontal, 20)
+                        .padding(.top, 8)
+                        .padding(.bottom, 12)
+
+                        // Categories grid
+                        LazyVGrid(
+                            columns: [
+                                GridItem(.flexible(), spacing: 12),
+                                GridItem(.flexible(), spacing: 12)
+                            ],
+                            spacing: 16
+                        ) {
+                            ForEach(categoriesWithIcons, id: \.0) { category, icon, description in
+                                NavigationLink {
+                                    FAQListView(
+                                        title: category,
+                                        items: items.filter { $0.category == category }
+                                    )
+                                } label: {
+                                    CategoryCard(
+                                        title: category,
+                                        icon: icon,
+                                        description: description,
+                                        itemCount: items.filter { $0.category == category }.count
+                                    )
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                            }
+                        }
+                        .padding(.horizontal, 20)
                     }
-                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
                 }
-                .padding(.bottom, 20)
-            }
-            .background(
-                LinearGradient(
-                    colors: [
-                        Color(.systemBackground),
-                        Color(.systemBlue).opacity(0.02)
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
+                .background(
+                    LinearGradient(
+                        colors: [
+                            Color(.systemBackground).opacity(0.8),
+                            Color(.systemBlue).opacity(0.02)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
                 )
-            )
+            }
             .navigationTitle("iPad-Hilfe")
             .navigationBarTitleDisplayMode(.large)
         }


### PR DESCRIPTION
## Summary
- Apply the DashboardBackground asset as a blurred, full-screen background to HelpHomeView
- Keep existing content overlayed with a light gradient for readability

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme iPadStartKlasse8 -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad5bada4832197c67027251abf4f