### PR TITLE
Use dashboard image as blurred background in help home view

### DIFF
--- a/iPadStartKlasse8/Features/Help/FAQDetailView.swift
+++ b/iPadStartKlasse8/Features/Help/FAQDetailView.swift
@@ -34,6 +34,7 @@ struct FAQDetailView: View {
                                 .font(.title3)
                                 .foregroundColor(isFavorited ? .red : .secondary)
                         }
+                        .buttonStyle(PressableButtonStyle())
                     }
                 }
                 .padding(20)
@@ -352,7 +353,7 @@ struct QuickActionButton: View {
             HStack(spacing: 8) {
                 Image(systemName: icon)
                     .font(.subheadline)
-                
+
                 Text(title)
                     .font(.subheadline)
                     .fontWeight(.medium)
@@ -363,6 +364,7 @@ struct QuickActionButton: View {
             .background(Color.blue.opacity(0.1))
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }
+        .buttonStyle(PressableButtonStyle())
     }
 }
 

--- a/iPadStartKlasse8/Features/Help/FAQListView.swift
+++ b/iPadStartKlasse8/Features/Help/FAQListView.swift
@@ -41,7 +41,7 @@ struct FAQListView: View {
                             searchText: searchText
                         )
                     }
-                    .buttonStyle(PlainButtonStyle())
+                    .buttonStyle(PressableButtonStyle())
                 }
                 
                 // Empty state

--- a/iPadStartKlasse8/Features/Help/HelpHomeView.swift
+++ b/iPadStartKlasse8/Features/Help/HelpHomeView.swift
@@ -20,63 +20,71 @@ struct HelpHomeView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                LazyVStack(spacing: 16) {
-                    // Header section
-                    VStack(spacing: 12) {
-                        Text("Wie kann ich dir helfen?")
-                            .font(.system(size: 28, weight: .bold, design: .rounded))
-                            .foregroundColor(.primary)
-                            .multilineTextAlignment(.center)
-                        
-                        Text("Finde schnell Antworten auf deine iPad-Fragen")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 8)
-                    .padding(.bottom, 12)
-                    
-                    // Categories grid
-                    LazyVGrid(
-                        columns: [
-                            GridItem(.flexible(), spacing: 12),
-                            GridItem(.flexible(), spacing: 12)
-                        ],
-                        spacing: 16
-                    ) {
-                        ForEach(categoriesWithIcons, id: \.0) { category, icon, description in
-                            NavigationLink {
-                                FAQListView(
-                                    title: category, 
-                                    items: items.filter { $0.category == category }
-                                )
-                            } label: {
-                                CategoryCard(
-                                    title: category,
-                                    icon: icon,
-                                    description: description,
-                                    itemCount: items.filter { $0.category == category }.count
-                                )
-                            }
-                            .buttonStyle(PlainButtonStyle())
+            ZStack {
+                Image("DashboardBackground")
+                    .resizable()
+                    .scaledToFill()
+                    .blur(radius: 20)
+                    .ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        // Header section
+                        VStack(spacing: 12) {
+                            Text("Wie kann ich dir helfen?")
+                                .font(.system(size: 28, weight: .bold, design: .rounded))
+                                .foregroundColor(.primary)
+                                .multilineTextAlignment(.center)
+
+                            Text("Finde schnell Antworten auf deine iPad-Fragen")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
                         }
+                        .padding(.horizontal, 20)
+                        .padding(.top, 32)
+                        .padding(.bottom, 12)
+
+                        // Categories grid
+                        LazyVGrid(
+                            columns: [
+                                GridItem(.flexible(), spacing: 12),
+                                GridItem(.flexible(), spacing: 12)
+                            ],
+                            spacing: 16
+                        ) {
+                            ForEach(categoriesWithIcons, id: \.0) { category, icon, description in
+                                NavigationLink {
+                                    FAQListView(
+                                        title: category,
+                                        items: items.filter { $0.category == category }
+                                    )
+                                } label: {
+                                    CategoryCard(
+                                        title: category,
+                                        icon: icon,
+                                        description: description,
+                                        itemCount: items.filter { $0.category == category }.count
+                                    )
+                                }
+                                .buttonStyle(PressableButtonStyle())
+                            }
+                        }
+                        .padding(.horizontal, 20)
                     }
-                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
                 }
-                .padding(.bottom, 20)
-            }
-            .background(
-                LinearGradient(
-                    colors: [
-                        Color(.systemBackground),
-                        Color(.systemBlue).opacity(0.02)
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
+                .background(
+                    LinearGradient(
+                        colors: [
+                            Color(.systemBackground).opacity(0.8),
+                            Color(.systemBlue).opacity(0.02)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
                 )
-            )
+            }
             .navigationTitle("iPad-Hilfe")
             .navigationBarTitleDisplayMode(.large)
         }

--- a/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
+++ b/iPadStartKlasse8/Features/Onboarding/OnboardingView.swift
@@ -90,7 +90,7 @@ struct OnboardingView: View {
                             Text("Los geht's")
                                 .font(.headline)
                                 .fontWeight(.semibold)
-                            
+
                             Image(systemName: "arrow.right")
                                 .font(.headline)
                         }
@@ -99,14 +99,15 @@ struct OnboardingView: View {
                         .frame(height: 56)
                         .background(
                             LinearGradient(
-                                colors: [.blue, .indigo], 
-                                startPoint: .leading, 
+                                colors: [.blue, .indigo],
+                                startPoint: .leading,
                                 endPoint: .trailing
                             )
                         )
                         .cornerRadius(16)
                         .shadow(color: .blue.opacity(0.3), radius: 8, x: 0, y: 4)
                     }
+                    .buttonStyle(PressableButtonStyle())
                     .padding(.horizontal, 32)
                     .padding(.bottom, 40)
                 }

--- a/iPadStartKlasse8/Shared/PressableButtonStyle.swift
+++ b/iPadStartKlasse8/Shared/PressableButtonStyle.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// A button style that slightly scales down the content when pressed
+/// to provide responsive feedback.
+struct PressableButtonStyle: ButtonStyle {
+    var scaleAmount: CGFloat = 0.97
+    var animation: Animation = .easeOut(duration: 0.15)
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? scaleAmount : 1.0)
+            .animation(animation, value: configuration.isPressed)
+    }
+}

--- a/iPadStartKlasse8/iPadStartKlasse8App.swift
+++ b/iPadStartKlasse8/iPadStartKlasse8App.swift
@@ -12,6 +12,7 @@ struct iPadStartKlasse8App: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .buttonStyle(PressableButtonStyle())
         }
     }
 }


### PR DESCRIPTION
## Summary
- Apply the DashboardBackground asset as a blurred, full-screen background to HelpHomeView
- Keep existing content overlayed with a light gradient for readability
- Increase spacing between navigation and help headers to avoid overlap in landscape
- Introduce a reusable PressableButtonStyle for a subtle scale-down press effect and apply it across buttons and navigation links

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -scheme iPadStartKlasse8 -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_6890ad5bada4832197c67027251abf4f