### PR TITLE
Handle markdown in FAQs and fix tile layout

### DIFF
--- a/iPadStartKlasse8/Features/Help/FAQDetailView.swift
+++ b/iPadStartKlasse8/Features/Help/FAQDetailView.swift
@@ -121,7 +121,17 @@ struct FAQDetailView: View {
 
 struct FormattedAnswerView: View {
     let answer: String
-    
+
+    /// Converts Markdown formatted strings into `Text` views.
+    /// Falls back to a plain `Text` if the conversion fails.
+    private func markdown(_ string: String) -> Text {
+        if let attributed = try? AttributedString(markdown: string) {
+            return Text(attributed)
+        } else {
+            return Text(string)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             ForEach(formatAnswer(), id: \.id) { section in
@@ -141,8 +151,8 @@ struct FormattedAnswerView: View {
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.blue)
-                                
-                                Text(item)
+
+                                markdown(item)
                                     .font(.subheadline)
                                     .foregroundColor(.primary)
                                     .fixedSize(horizontal: false, vertical: true)
@@ -150,20 +160,20 @@ struct FormattedAnswerView: View {
                         }
                     }
                     .padding(.leading, 8)
-                    
+
                 case .paragraph:
-                    Text(section.content)
+                    markdown(section.content)
                         .font(.subheadline)
                         .foregroundColor(.primary)
                         .fixedSize(horizontal: false, vertical: true)
-                    
+
                 case .important:
                     HStack(alignment: .top, spacing: 8) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.subheadline)
                             .foregroundColor(.orange)
-                        
-                        Text(section.content)
+
+                        markdown(section.content)
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundColor(.primary)
@@ -172,14 +182,14 @@ struct FormattedAnswerView: View {
                     .padding(12)
                     .background(Color.orange.opacity(0.1))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                    
+
                 case .tip:
                     HStack(alignment: .top, spacing: 8) {
                         Image(systemName: "lightbulb.fill")
                             .font(.subheadline)
                             .foregroundColor(.yellow)
-                        
-                        Text(section.content)
+
+                        markdown(section.content)
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundColor(.primary)

--- a/iPadStartKlasse8/Features/Help/HelpHomeView.swift
+++ b/iPadStartKlasse8/Features/Help/HelpHomeView.swift
@@ -42,18 +42,13 @@ struct HelpHomeView: View {
                                 .multilineTextAlignment(.center)
                         }
                         .padding(.horizontal, 20)
-
                         .padding(.top, 32)
-
-                        .padding(.top, 8)
-
                         .padding(.bottom, 12)
 
                         // Categories grid
                         LazyVGrid(
                             columns: [
-                                GridItem(.flexible(), spacing: 12),
-                                GridItem(.flexible(), spacing: 12)
+                                GridItem(.adaptive(minimum: 300), spacing: 12)
                             ],
                             spacing: 16
                         ) {
@@ -73,8 +68,6 @@ struct HelpHomeView: View {
                                 }
 
                                 .buttonStyle(PressableButtonStyle())
-
-                                .buttonStyle(PlainButtonStyle())
 
                             }
                         }
@@ -151,7 +144,7 @@ struct CategoryCard: View {
             }
         }
         .padding(16)
-        .frame(height: 140)
+        .frame(maxWidth: .infinity, minHeight: 140)
         .background(
             RoundedRectangle(cornerRadius: 16)
                 .fill(Color(.secondarySystemBackground))


### PR DESCRIPTION
## Summary
- Render markdown in FAQ answers so formatting like bold text displays without raw markup
- Use adaptive grid for help categories so tiles resize without clipping in portrait

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c6d12d808321bb5e169f216a4f8b